### PR TITLE
Feature/pentaho production integration

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -32,6 +32,31 @@ jobs:
           echo "owner_lowercase=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
         id: git_hashes
 
+      - name: Prepare Pentaho Plugin
+        run: |
+          echo "Preparing Pentaho Plugin..."
+          mkdir -p pentaho-dist/plugins
+          mkdir -p pentaho-dist/reports
+          
+          # Unzip the plugin
+          unzip -o fineract-adorsys-pentaho/MifosSecurityPlugin-1.12.1.zip -d pentaho-temp
+          
+          # Copy JARs (Handling potential internal folder structure)
+          if [ -d "pentaho-temp/MifosSecurityPlugin-1.12.1/lib" ]; then
+            echo "Found lib directory, copying JARs..."
+            cp pentaho-temp/MifosSecurityPlugin-1.12.1/lib/*.jar pentaho-dist/plugins/
+          else
+            echo "Copying JARs from root..."
+            cp pentaho-temp/MifosSecurityPlugin-1.12.1/*.jar pentaho-dist/plugins/ || echo "No JARs found in root either!"
+          fi
+          
+          # Copy Reports (From the repo folder using Postgresql)
+          echo "Copying Reports..."
+          cp -r fineract-adorsys-pentaho/MifosSecurityPlugin-1.12.1/Postgresql pentaho-dist/reports/
+          
+          echo "Pentaho preparation complete."
+          ls -R pentaho-dist
+
       - name: Build the Apache Fineract image
         run:  |
           TAGS="${{ steps.git_hashes.outputs.short_hash }},${{ steps.git_hashes.outputs.long_hash }}"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -32,31 +32,6 @@ jobs:
           echo "owner_lowercase=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
         id: git_hashes
 
-      - name: Prepare Pentaho Plugin
-        run: |
-          echo "Preparing Pentaho Plugin..."
-          mkdir -p pentaho-dist/plugins
-          mkdir -p pentaho-dist/reports
-          
-          # Unzip the plugin
-          unzip -o fineract-adorsys-pentaho/MifosSecurityPlugin-1.12.1.zip -d pentaho-temp
-          
-          # Copy JARs (Handling potential internal folder structure)
-          if [ -d "pentaho-temp/MifosSecurityPlugin-1.12.1/lib" ]; then
-            echo "Found lib directory, copying JARs..."
-            cp pentaho-temp/MifosSecurityPlugin-1.12.1/lib/*.jar pentaho-dist/plugins/
-          else
-            echo "Copying JARs from root..."
-            cp pentaho-temp/MifosSecurityPlugin-1.12.1/*.jar pentaho-dist/plugins/ || echo "No JARs found in root either!"
-          fi
-          
-          # Copy Reports (From the repo folder)
-          echo "Copying Reports..."
-          cp -r fineract-adorsys-pentaho/MifosSecurityPlugin-1.12.1/Postgresql pentaho-dist/reports/
-          
-          echo "Pentaho preparation complete."
-          ls -R pentaho-dist
-
       - name: Build the Apache Fineract image
         run:  |
           TAGS="${{ steps.git_hashes.outputs.short_hash }},${{ steps.git_hashes.outputs.long_hash }}"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -32,6 +32,31 @@ jobs:
           echo "owner_lowercase=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
         id: git_hashes
 
+      - name: Prepare Pentaho Plugin
+        run: |
+          echo "Preparing Pentaho Plugin..."
+          mkdir -p pentaho-dist/plugins
+          mkdir -p pentaho-dist/reports
+          
+          # Unzip the plugin
+          unzip -o fineract-adorsys-pentaho/MifosSecurityPlugin-1.12.1.zip -d pentaho-temp
+          
+          # Copy JARs (Handling potential internal folder structure)
+          if [ -d "pentaho-temp/MifosSecurityPlugin-1.12.1/lib" ]; then
+            echo "Found lib directory, copying JARs..."
+            cp pentaho-temp/MifosSecurityPlugin-1.12.1/lib/*.jar pentaho-dist/plugins/
+          else
+            echo "Copying JARs from root..."
+            cp pentaho-temp/MifosSecurityPlugin-1.12.1/*.jar pentaho-dist/plugins/ || echo "No JARs found in root either!"
+          fi
+          
+          # Copy Reports (From the repo folder)
+          echo "Copying Reports..."
+          cp -r fineract-adorsys-pentaho/MifosSecurityPlugin-1.12.1/Postgresql pentaho-dist/reports/
+          
+          echo "Pentaho preparation complete."
+          ls -R pentaho-dist
+
       - name: Build the Apache Fineract image
         run:  |
           TAGS="${{ steps.git_hashes.outputs.short_hash }},${{ steps.git_hashes.outputs.long_hash }}"

--- a/custom/docker/build.gradle
+++ b/custom/docker/build.gradle
@@ -53,6 +53,23 @@ jib {
         ports = ['8080/tcp', '8443/tcp']
         labels = [maintainer: 'Aleksandar Vidakovic <aleks@apache.org>']
         user = 'nobody:nogroup'
+        environment = [
+            'FINERACT_PENTAHO_REPORTS_PATH': '/pentahoReports/Postgresql/',
+            'JAVA_TOOL_OPTIONS': '-Dloader.path=/app/plugins/'
+        ]
+    }
+
+    extraDirectories {
+        paths {
+            path {
+                from = file("${rootDir}/pentaho-dist/plugins")
+                into = '/app/plugins'
+            }
+            path {
+                from = file("${rootDir}/pentaho-dist/reports")
+                into = '/pentahoReports'
+            }
+        }
     }
 
     allowInsecureRegistries = true

--- a/custom/docker/build.gradle
+++ b/custom/docker/build.gradle
@@ -53,23 +53,6 @@ jib {
         ports = ['8080/tcp', '8443/tcp']
         labels = [maintainer: 'Aleksandar Vidakovic <aleks@apache.org>']
         user = 'nobody:nogroup'
-        environment = [
-            'FINERACT_PENTAHO_REPORTS_PATH': '/pentahoReports/Postgresql/',
-            'JAVA_TOOL_OPTIONS': '-Dloader.path=/app/plugins/'
-        ]
-    }
-
-    extraDirectories {
-        paths {
-            path {
-                from = file("${rootDir}/pentaho-dist/plugins")
-                into = '/app/plugins'
-            }
-            path {
-                from = file("${rootDir}/pentaho-dist/reports")
-                into = '/pentahoReports'
-            }
-        }
     }
 
     allowInsecureRegistries = true


### PR DESCRIPTION
- Update custom/docker/build.gradle to copy Pentaho JARs and Reports into the Docker image.
- Configure Jib to set FINERACT_PENTAHO_REPORTS_PATH and JAVA_TOOL_OPTIONS environment variables automatically.
- Update .github/workflows/publish-ghcr.yml to unzip the Pentaho plugin zip before the build steps to ensure JARs are available.
- Switch report source to Postgresql for production environment.