### PR TITLE
fix(docker): ensure Pentaho plugins are added to classpath

### DIFF
--- a/custom/docker/build.gradle
+++ b/custom/docker/build.gradle
@@ -53,9 +53,9 @@ jib {
         ports = ['8080/tcp', '8443/tcp']
         labels = [maintainer: 'Aleksandar Vidakovic <aleks@apache.org>']
         user = 'nobody:nogroup'
+        extraClasspath = ['/app/plugins/*']
         environment = [
-            'FINERACT_PENTAHO_REPORTS_PATH': '/pentahoReports/Postgresql/',
-            'JAVA_TOOL_OPTIONS': '-Dloader.path=/app/plugins/'
+            'FINERACT_PENTAHO_REPORTS_PATH': '/pentahoReports/Postgresql/'
         ]
     }
 


### PR DESCRIPTION
The Docker image build was relying on `loader.path` to load Pentaho plugins from `/app/plugins`, but the application entry point was bypassing `PropertiesLauncher`, causing this setting to be ignored.


- Adds `/app/plugins/*` to the Jib `extraClasspath` configuration to explicitly include plugins in the classpath.
- Removes the ineffective `loader.path` setting from `JAVA_TOOL_OPTIONS`.
