### PR TITLE
chore: Disable the Docker Hub publish workflow

### DIFF
--- a/.github/workflows/publish-dockerhub.yml
+++ b/.github/workflows/publish-dockerhub.yml
@@ -1,10 +1,6 @@
 name: Fineract Publish to DockerHub
 on:
-  push:
-    branches:
-      - develop
-    tags:
-      - 1.*
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
- The `publish-dockerhub.yml` workflow is inherited from the upstream `apache/fineract` repository and is configured to publish images to the official Apache Docker Hub.

- This workflow consistently fails in our forked environment as it requires secrets (`DOCKERHUB_USER`, `DOCKERHUB_TOKEN`) that are not available to us.

- Since we do not publish to the official Docker Hub, the workflow's trigger has been changed from `push` to `workflow_dispatch` to disable it from running automatically. This resolves the CI failures while keeping the file intact to prevent future merge conflicts with the upstream repository.
