### PR TITLE
chore: Disable inherited CI workflows

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,25 @@
+name: Fineract PR Compliance
+
+on:
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  verify-title:
+    name: Validate Jira Ticket ID
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify Title Format
+        run: |
+          title="${{ github.event.pull_request.title }}"
+          regex="^FINERACT-[0-9]+: "
+
+          if [[ ! "$title" =~ $regex ]]; then
+            echo "::error::PR title '$title' is invalid."
+            echo "::error::It must start with a Jira Ticket ID (e.g., 'FINERACT-123: Description...')."
+            exit 1
+          fi
+          echo "Success: PR title matches the required format."

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,36 @@
+name: Fineract Sonarqube
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    env:
+        TZ: Asia/Kolkata
+        SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+        SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+        SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+        DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+        JAVA_BINARIES: .
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+      - name: Setup Gradle and Validate Wrapper
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          validate-wrappers: true
+      - name: Build
+        run: ./gradlew --no-daemon --console=plain :fineract-provider:build -x test -x cucumber
+      - name: Sonar
+        run: ./gradlew --no-daemon --console=plain -Dsonar.verbose=true -Dsonar.token=$SONAR_TOKEN -Dsonar.host.url=$SONAR_HOST_URL -Dsonar.organization=$SONAR_ORGANIZATION -Dsonar.projectKey=$SONAR_PROJECT_KEY -Dsonar.java.binaries=$JAVA_BINARIES --info --stacktrace sonar

--- a/.github/workflows/verify-commits.yml
+++ b/.github/workflows/verify-commits.yml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Fineract Signed Commits Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-signatures:
+    name: Verify Commit Signatures
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Verify signatures
+        run: |
+          chmod +x scripts/verify-signed-commits.sh
+          ./scripts/verify-signed-commits.sh \
+            --base-ref origin/${{ github.base_ref }} \
+            --head-ref ${{ github.event.pull_request.head.sha }} \
+            --strict


### PR DESCRIPTION
- Disables CI workflows inherited from the upstream `apache/fineract` repository that are not applicable to this fork.

- The `pr-title-check.yml` workflow is disabled because it enforces an Apache-specific Jira ticket convention in pull request titles.

- The `sonarqube.yml` workflow is disabled because it requires secrets for the Apache SonarCloud instance, which are unavailable in this repository.

Both workflows have had their triggers changed to `workflow_dispatch` to prevent them from running automatically. This approach preserves the files to avoid potential merge conflicts with the upstream repository in the future.
