### PR TITLE
Fix SMS gateway workflow path trigger

### DIFF
--- a/.github/workflows/build-push-sms-gateway.yml
+++ b/.github/workflows/build-push-sms-gateway.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - 'v*'
     paths:
-      - '../../fineract-adorsys-sms-gateway/**'
+      - 'fineract-adorsys-sms-gateway/**'
       - '.github/workflows/build-push-sms-gateway.yml'
 
 env:


### PR DESCRIPTION
## Summary

- Fixed broken paths filter in .github/workflows/build-push-sms-gateway.yml
- Changed '../../fineract-adorsys-sms-gateway/**' to 'fineract-adorsys-sms-gateway/**'
- The old path used relative '../' segments that never matched any files, so the SMS gateway Docker build has not triggered since this workflow was added
- Config CLI workflow paths are already correct -- no changes needed

## Why it matters

This workflow is responsible for building and pushing the SMS Gateway native image to GHCR. Without this fix, it silently never runs, leaving stale container images.