### PR TITLE
fix: resolve SMS provider test compilation errors

### DIFF
--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/AvlytextSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/AvlytextSmsProvider.java
@@ -105,20 +105,20 @@ public class AvlytextSmsProvider implements SmsProvider {
         }
     }
 
-    // DTOs for Avlytext API
-    private record AvlytextSmsRequest(
+    // DTOs for Avlytext API - public for test access
+    public record AvlytextSmsRequest(
             String sender,
             String recipient,
             @JsonProperty("text") String message
     ) {}
 
-    private record AvlytextSmsResponse(
+    public record AvlytextSmsResponse(
             boolean success,
             String messageId,
             AvlytextError error
     ) {}
 
-    private record AvlytextError(
+    public record AvlytextError(
             String code,
             String message
     ) {}

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/OrangeSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/OrangeSmsProvider.java
@@ -258,31 +258,31 @@ public class OrangeSmsProvider implements SmsProvider {
         }
     }
 
-    // DTOs for Orange API - matching expected structure exactly
+    // DTOs for Orange API - public for test access
     // The Orange API expects: {"outboundSMSMessageRequest": {"address": "...", "senderAddress": "...", "outboundSMSTextMessage": {"message": "..."}}}
 
-    private record OrangeSmsRequest(
+    public record OrangeSmsRequest(
             @JsonProperty("outboundSMSMessageRequest") OutboundSMSMessageRequest outboundSMSMessageRequest
     ) {}
 
-    private record OutboundSMSMessageRequest(
+    public record OutboundSMSMessageRequest(
             @JsonProperty("address") String address,
             @JsonProperty("senderAddress") String senderAddress,
             @JsonProperty("outboundSMSTextMessage") OutboundSMSTextMessage outboundSMSTextMessage,
             @JsonProperty("senderName") @JsonInclude(JsonInclude.Include.NON_NULL) String senderName
     ) {}
 
-    private record OutboundSMSTextMessage(
+    public record OutboundSMSTextMessage(
             @JsonProperty("message") String message
     ) {}
 
-    private record OrangeTokenResponse(
+    public record OrangeTokenResponse(
             @JsonProperty("access_token") String accessToken,
             @JsonProperty("token_type") String tokenType,
             @JsonProperty("expires_in") long expiresIn
     ) {}
 
-    private record OrangeSmsResponse(
+    public record OrangeSmsResponse(
             @JsonProperty("transactionId") String transactionId
     ) {}
 }

--- a/fineract-adorsys-sms-gateway/src/test/java/com/example/smsgateway/provider/OrangeSmsProviderTest.java
+++ b/fineract-adorsys-sms-gateway/src/test/java/com/example/smsgateway/provider/OrangeSmsProviderTest.java
@@ -145,7 +145,7 @@ class OrangeSmsProviderTest {
     @Test
     void testSendNotConfigured() {
         OrangeSmsProvider unconfiguredProvider = new OrangeSmsProvider(
-                restTemplate, objectMapper, "", "", "", "", "", "", "", ""
+                restTemplate, objectMapper, "", "", "", "", "", "", ""
         );
 
         SmsMessage message = new SmsMessage("+237698765432", "Test message", MessageType.OTP, "orange", Map.of());


### PR DESCRIPTION
- Fix constructor argument count in OrangeSmsProviderTest (9 args, not 10)
- Make OrangeSmsProvider DTO records public for test access
- Make AvlytextSmsProvider DTO records public for test access

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
