### PR TITLE
feat(sms-gateway): add AWS SNS and WhatsApp providers with multi-fallback chain

### DIFF
--- a/fineract-adorsys-sms-gateway/PROVIDERS.md
+++ b/fineract-adorsys-sms-gateway/PROVIDERS.md
@@ -28,7 +28,11 @@ The provider is selected by name at runtime. The selected provider receives a no
 | `console` | `ConsoleSmsProvider` | Local development provider that logs the SMS body to application logs. Use this for local OTP testing. |
 | `mock` | `MockSmsProvider` | Test provider for integration tests or environments where delivery is disabled. |
 | `twilio` | `TwilioSmsProvider` | Twilio-backed provider for real SMS delivery. |
+| `orange` | `OrangeSmsProvider` | Orange SMS API for Francophone Africa (Cameroon-ready with MSISDN normalization and OAuth2). |
+| `avlytext` | `AvlytextSmsProvider` | Avlytext SMS aggregator for African markets. |
 | `custom-http` | `CustomHttpSmsProvider` | Generic HTTPS provider integration for external SMS vendors. |
+| `sns` | `SnsSmsProvider` | AWS SNS for global SMS delivery with configurable sender ID and max price. |
+| `whatsapp` | `WhatsappSmsProvider` | WhatsApp message delivery via GOWA sidecar (aldinokemal2104/go-whatsapp-web-multidevice). |
 
 ## Switching providers
 
@@ -39,15 +43,15 @@ export SMS_PROVIDER_PRIMARY=console
 mvn spring-boot:run
 ```
 
-Optional fallback delivery is controlled by `SMS_PROVIDER_FALLBACK`.
+Optional fallback delivery is controlled by `SMS_PROVIDER_FALLBACK`. Supports a **comma-separated chain** of providers tried in order.
 
 ```bash
 export SMS_PROVIDER_PRIMARY=twilio
-export SMS_PROVIDER_FALLBACK=console
+export SMS_PROVIDER_FALLBACK=orange,avlytext,console
 mvn spring-boot:run
 ```
 
-When a send attempt fails through the primary provider, the gateway can attempt the fallback provider if it is configured and available.
+When a send attempt fails through the primary provider, the gateway tries each fallback provider in order until one succeeds. If all fail, the last error is returned.
 
 ## Local development: console provider
 
@@ -105,6 +109,41 @@ mvn spring-boot:run
 ```
 
 The custom HTTP provider requires HTTPS for external calls.
+
+## AWS SNS provider
+
+Use `sns` for delivery via AWS SNS.
+
+```bash
+export SMS_PROVIDER_PRIMARY=sns
+export SMS_PROVIDER_FALLBACK=console
+export SMS_SNS_REGION=eu-west-1
+export SMS_SNS_SENDER_ID=Webank
+export SMS_SNS_MAX_PRICE=1.00
+mvn spring-boot:run
+```
+
+`SMS_SNS_REGION` is required. Credentials are resolved via the [default AWS credentials chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html) (environment variables, ~/.aws/credentials, IAM roles).
+
+Optional attributes:
+- `SMS_SNS_SENDER_ID` — displayed as the SMS sender (default: `Webank`)
+- `SMS_SNS_MAX_PRICE` — max price per SMS in USD (no default)
+
+## WhatsApp provider
+
+Use `whatsapp` for delivery via WhatsApp through a GOWA sidecar instance.
+
+```bash
+export SMS_PROVIDER_PRIMARY=whatsapp
+export SMS_PROVIDER_FALLBACK=console
+export SMS_WHATSAPP_BASE_URL=http://gowa:8080
+export SMS_WHATSAPP_DEVICE_ID=device-1
+mvn spring-boot:run
+```
+
+`SMS_WHATSAPP_BASE_URL` is required. The sidecar must expose a `POST /send/message` endpoint accepting `{"phone": "...", "message": "..."}`.
+
+The recommended sidecar is [aldinokemal2104/go-whatsapp-web-multidevice](https://github.com/aldinokemal2104/go-whatsapp-web-multidevice).
 
 ## Per-request provider override
 

--- a/fineract-adorsys-sms-gateway/pom.xml
+++ b/fineract-adorsys-sms-gateway/pom.xml
@@ -41,6 +41,12 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sns</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
         </dependency>

--- a/fineract-adorsys-sms-gateway/pom.xml
+++ b/fineract-adorsys-sms-gateway/pom.xml
@@ -15,6 +15,7 @@
     <description>SMS Gateway for Fineract</description>
     <properties>
         <java.version>17</java.version>
+        <lombok.version>1.18.30</lombok.version>
     </properties>
     <dependencies>
         <dependency>
@@ -74,19 +75,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok-maven-plugin</artifactId>
-                <version>1.18.20.0</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>delombok</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+
         </plugins>
     </build>
 

--- a/fineract-adorsys-sms-gateway/pom.xml
+++ b/fineract-adorsys-sms-gateway/pom.xml
@@ -16,7 +16,19 @@
     <properties>
         <java.version>17</java.version>
         <lombok.version>1.18.30</lombok.version>
+        <awssdk.version>2.26.25</awssdk.version>
     </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${awssdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -44,7 +56,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sns</artifactId>
-            <version>2.20.0</version>
         </dependency>
 
         <dependency>

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/ApiKeyFilter.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/ApiKeyFilter.java
@@ -5,12 +5,21 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@Component
+/**
+ * API key filter for securing /otp/ and /sms/ endpoints.
+ *
+ * <p>Registration is handled exclusively by {@link FilterConfig} via
+ * {@code FilterRegistrationBean} with explicit URL patterns. This class
+ * is intentionally <b>not</b> annotated with {@code @Component} to avoid
+ * double-registration by Spring Boot's auto-scan.</p>
+ *
+ * <p><b>Fail-closed:</b> If {@code SMS_GATEWAY_API_KEY} is not configured,
+ * all requests to protected endpoints are rejected with 503.</p>
+ */
 public class ApiKeyFilter extends OncePerRequestFilter {
 
     private static final String API_KEY_HEADER = "X-KYC-Api-Key";
@@ -21,18 +30,21 @@ public class ApiKeyFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        
-        String path = request.getRequestURI();
-        // Only apply to /api/v1/otp/, /otp/ and /sms/ endpoints
-        if (path.startsWith("/api/v1/otp/") || path.startsWith("/otp/") || path.startsWith("/sms/")) {
-            String apiKey = request.getHeader(API_KEY_HEADER);
-            if (expectedApiKey != null && !expectedApiKey.isEmpty() && !expectedApiKey.equals(apiKey)) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.getWriter().write("Unauthorized");
-                return;
-            }
+
+        // Fail-closed: reject all requests if the API key is not configured
+        if (expectedApiKey == null || expectedApiKey.isEmpty()) {
+            response.setStatus(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
+            response.getWriter().write("SMS gateway API key not configured");
+            return;
         }
-        
+
+        String apiKey = request.getHeader(API_KEY_HEADER);
+        if (!expectedApiKey.equals(apiKey)) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("Unauthorized");
+            return;
+        }
+
         filterChain.doFilter(request, response);
     }
 }

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/ApiKeyFilter.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/ApiKeyFilter.java
@@ -1,0 +1,38 @@
+package com.example.smsgateway.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class ApiKeyFilter extends OncePerRequestFilter {
+
+    private static final String API_KEY_HEADER = "X-KYC-Api-Key";
+
+    @Value("${sms.gateway.api-key:}")
+    private String expectedApiKey;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        
+        String path = request.getRequestURI();
+        // Only apply to /api/v1/otp/, /otp/ and /sms/ endpoints
+        if (path.startsWith("/api/v1/otp/") || path.startsWith("/otp/") || path.startsWith("/sms/")) {
+            String apiKey = request.getHeader(API_KEY_HEADER);
+            if (expectedApiKey != null && !expectedApiKey.isEmpty() && !expectedApiKey.equals(apiKey)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.getWriter().write("Unauthorized");
+                return;
+            }
+        }
+        
+        filterChain.doFilter(request, response);
+    }
+}

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/FilterConfig.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/FilterConfig.java
@@ -1,0 +1,17 @@
+package com.example.smsgateway.config;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilter(ApiKeyFilter filter) {
+        FilterRegistrationBean<ApiKeyFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(filter);
+        registrationBean.addUrlPatterns("/api/v1/otp/*", "/otp/*", "/sms/*");
+        return registrationBean;
+    }
+}

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/FilterConfig.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/FilterConfig.java
@@ -8,7 +8,12 @@ import org.springframework.context.annotation.Configuration;
 public class FilterConfig {
 
     @Bean
-    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilter(ApiKeyFilter filter) {
+    public ApiKeyFilter apiKeyFilter() {
+        return new ApiKeyFilter();
+    }
+
+    @Bean
+    public FilterRegistrationBean<ApiKeyFilter> apiKeyFilterRegistration(ApiKeyFilter filter) {
         FilterRegistrationBean<ApiKeyFilter> registrationBean = new FilterRegistrationBean<>();
         registrationBean.setFilter(filter);
         registrationBean.addUrlPatterns("/api/v1/otp/*", "/otp/*", "/sms/*");

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/SnsSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/SnsSmsProvider.java
@@ -1,0 +1,109 @@
+package com.example.smsgateway.provider;
+
+import com.example.smsgateway.model.SmsMessage;
+import com.example.smsgateway.model.SmsSendResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+
+@Component
+public class SnsSmsProvider implements SmsProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(SnsSmsProvider.class);
+
+    private final String region;
+    private final String senderId;
+    private final String maxPrice;
+
+    private volatile SnsClient snsClient;
+    private final Object clientLock = new Object();
+
+    public SnsSmsProvider(
+            @Value("${sms.sns.region:}") String region,
+            @Value("${sms.sns.sender-id:Webank}") String senderId,
+            @Value("${sms.sns.max-price:}") String maxPrice) {
+        this.region = region;
+        this.senderId = senderId;
+        this.maxPrice = maxPrice;
+    }
+
+    @Override
+    public String name() {
+        return "sns";
+    }
+
+    private SnsClient getClient() {
+        if (snsClient != null) {
+            return snsClient;
+        }
+        synchronized (clientLock) {
+            if (snsClient != null) {
+                return snsClient;
+            }
+            if (!isConfigured()) {
+                logger.info("SNS SMS provider not configured (missing region)");
+                return null;
+            }
+            try {
+                snsClient = SnsClient.builder()
+                        .region(Region.of(region))
+                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .build();
+                logger.info("SNS SMS provider initialized for region {}", region);
+            } catch (Exception e) {
+                logger.error("Failed to initialize SNS client for region {}", region, e);
+            }
+            return snsClient;
+        }
+    }
+
+    @Override
+    public SmsSendResult send(SmsMessage message) {
+        SnsClient client = getClient();
+        if (client == null) {
+            return SmsSendResult.failure(name(), "PROVIDER_NOT_CONFIGURED");
+        }
+
+        try {
+            PublishRequest.Builder requestBuilder = PublishRequest.builder()
+                    .phoneNumber(message.to())
+                    .message(message.body());
+
+            java.util.Map<String, MessageAttributeValue> attrs = new java.util.HashMap<>();
+            if (StringUtils.hasText(senderId)) {
+                attrs.put("AWS.SNS.SMS.SenderID", MessageAttributeValue.builder()
+                        .stringValue(senderId).dataType("String").build());
+                attrs.put("AWS.SNS.SMS.SMSType", MessageAttributeValue.builder()
+                        .stringValue("Transactional").dataType("String").build());
+            }
+            if (StringUtils.hasText(maxPrice)) {
+                attrs.put("AWS.SNS.SMS.MaxPrice", MessageAttributeValue.builder()
+                        .stringValue(maxPrice).dataType("Number").build());
+            }
+            if (!attrs.isEmpty()) {
+                requestBuilder.messageAttributes(attrs);
+            }
+
+            PublishResponse response = client.publish(requestBuilder.build());
+            logger.info("SNS SMS sent to {}: messageId={}", message.to(), response.messageId());
+            return SmsSendResult.success(name(), response.messageId());
+
+        } catch (Exception e) {
+            logger.error("SNS SMS send failed for {}", message.to(), e);
+            return SmsSendResult.failure(name(), "PROVIDER_ERROR");
+        }
+    }
+
+    private boolean isConfigured() {
+        return StringUtils.hasText(region);
+    }
+}

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/SnsSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/SnsSmsProvider.java
@@ -2,6 +2,7 @@ package com.example.smsgateway.provider;
 
 import com.example.smsgateway.model.SmsMessage;
 import com.example.smsgateway.model.SmsSendResult;
+import jakarta.annotation.PreDestroy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +15,8 @@ import software.amazon.awssdk.services.sns.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 import software.amazon.awssdk.services.sns.model.PublishResponse;
 
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class SnsSmsProvider implements SmsProvider {
@@ -66,6 +69,14 @@ public class SnsSmsProvider implements SmsProvider {
         }
     }
 
+    @PreDestroy
+    public void destroy() {
+        if (snsClient != null) {
+            snsClient.close();
+            logger.info("SNS client closed");
+        }
+    }
+
     @Override
     public SmsSendResult send(SmsMessage message) {
         SnsClient client = getClient();
@@ -78,7 +89,7 @@ public class SnsSmsProvider implements SmsProvider {
                     .phoneNumber(message.to())
                     .message(message.body());
 
-            java.util.Map<String, MessageAttributeValue> attrs = new java.util.HashMap<>();
+            Map<String, MessageAttributeValue> attrs = new HashMap<>();
             if (StringUtils.hasText(senderId)) {
                 attrs.put("AWS.SNS.SMS.SenderID", MessageAttributeValue.builder()
                         .stringValue(senderId).dataType("String").build());
@@ -94,16 +105,23 @@ public class SnsSmsProvider implements SmsProvider {
             }
 
             PublishResponse response = client.publish(requestBuilder.build());
-            logger.info("SNS SMS sent to {}: messageId={}", message.to(), response.messageId());
+            logger.info("SNS SMS sent to {}: messageId={}", maskPhone(message.to()), response.messageId());
             return SmsSendResult.success(name(), response.messageId());
 
         } catch (Exception e) {
-            logger.error("SNS SMS send failed for {}", message.to(), e);
+            logger.error("SNS SMS send failed for {}", maskPhone(message.to()), e);
             return SmsSendResult.failure(name(), "PROVIDER_ERROR");
         }
     }
 
     private boolean isConfigured() {
         return StringUtils.hasText(region);
+    }
+
+    private String maskPhone(String phone) {
+        if (phone == null || phone.length() < 6) {
+            return "***";
+        }
+        return phone.substring(0, 4) + "***" + phone.substring(phone.length() - 2);
     }
 }

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/WhatsappSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/WhatsappSmsProvider.java
@@ -5,6 +5,7 @@ import com.example.smsgateway.model.SmsSendResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -15,6 +16,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Map;
 
 @Component
@@ -27,10 +29,13 @@ public class WhatsappSmsProvider implements SmsProvider {
     private final String deviceId;
 
     public WhatsappSmsProvider(
-            RestTemplate restTemplate,
+            RestTemplateBuilder restTemplateBuilder,
             @Value("${sms.whatsapp.base-url:}") String baseUrl,
             @Value("${sms.whatsapp.device-id:}") String deviceId) {
-        this.restTemplate = restTemplate;
+        this.restTemplate = restTemplateBuilder
+                .setConnectTimeout(Duration.ofSeconds(5))
+                .setReadTimeout(Duration.ofSeconds(10))
+                .build();
         this.baseUrl = baseUrl;
         this.deviceId = deviceId;
     }
@@ -65,15 +70,15 @@ public class WhatsappSmsProvider implements SmsProvider {
                 ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
 
                 if (response.getStatusCode().is2xxSuccessful()) {
-                    logger.info("WhatsApp message sent to {}", message.to());
+                    logger.info("WhatsApp message sent to {}", maskPhone(message.to()));
                     return SmsSendResult.success(name(), null);
                 } else {
-                    logger.warn("WhatsApp provider returned {} for {}", response.getStatusCode(), message.to());
+                    logger.warn("WhatsApp provider returned {} for {}", response.getStatusCode(), maskPhone(message.to()));
                     return SmsSendResult.failure(name(), "PROVIDER_REJECTED");
                 }
 
             } catch (Exception ex) {
-                logger.error("Error sending WhatsApp message to {}", message.to(), ex);
+                logger.error("Error sending WhatsApp message to {}", maskPhone(message.to()), ex);
                 return SmsSendResult.failure(name(), mapExceptionToErrorCode(ex));
             }
         }, name());
@@ -88,5 +93,12 @@ public class WhatsappSmsProvider implements SmsProvider {
             return "INVALID_INPUT";
         }
         return "PROVIDER_ERROR";
+    }
+
+    private String maskPhone(String phone) {
+        if (phone == null || phone.length() < 6) {
+            return "***";
+        }
+        return phone.substring(0, 4) + "***" + phone.substring(phone.length() - 2);
     }
 }

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/WhatsappSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/WhatsappSmsProvider.java
@@ -2,7 +2,6 @@ package com.example.smsgateway.provider;
 
 import com.example.smsgateway.model.SmsMessage;
 import com.example.smsgateway.model.SmsSendResult;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +13,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @Component
@@ -47,9 +48,9 @@ public class WhatsappSmsProvider implements SmsProvider {
 
         return RetryHelper.executeWithRetry(() -> {
             try {
-                String url = baseUrl.trimEnd('/') + "/send/message";
+                String url = (baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl) + "/send/message";
                 if (StringUtils.hasText(deviceId)) {
-                    url += "?device_id=" + deviceId;
+                    url += "?device_id=" + URLEncoder.encode(deviceId, StandardCharsets.UTF_8);
                 }
 
                 HttpHeaders headers = new HttpHeaders();

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/WhatsappSmsProvider.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/provider/WhatsappSmsProvider.java
@@ -1,0 +1,91 @@
+package com.example.smsgateway.provider;
+
+import com.example.smsgateway.model.SmsMessage;
+import com.example.smsgateway.model.SmsSendResult;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component
+public class WhatsappSmsProvider implements SmsProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(WhatsappSmsProvider.class);
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl;
+    private final String deviceId;
+
+    public WhatsappSmsProvider(
+            RestTemplate restTemplate,
+            @Value("${sms.whatsapp.base-url:}") String baseUrl,
+            @Value("${sms.whatsapp.device-id:}") String deviceId) {
+        this.restTemplate = restTemplate;
+        this.baseUrl = baseUrl;
+        this.deviceId = deviceId;
+    }
+
+    @Override
+    public String name() {
+        return "whatsapp";
+    }
+
+    @Override
+    public SmsSendResult send(SmsMessage message) {
+        if (!isConfigured()) {
+            return SmsSendResult.failure(name(), "PROVIDER_NOT_CONFIGURED");
+        }
+
+        return RetryHelper.executeWithRetry(() -> {
+            try {
+                String url = baseUrl.trimEnd('/') + "/send/message";
+                if (StringUtils.hasText(deviceId)) {
+                    url += "?device_id=" + deviceId;
+                }
+
+                HttpHeaders headers = new HttpHeaders();
+                headers.setContentType(MediaType.APPLICATION_JSON);
+
+                Map<String, String> payload = Map.of(
+                        "phone", message.to(),
+                        "message", message.body()
+                );
+
+                HttpEntity<Map<String, String>> entity = new HttpEntity<>(payload, headers);
+                ResponseEntity<String> response = restTemplate.postForEntity(url, entity, String.class);
+
+                if (response.getStatusCode().is2xxSuccessful()) {
+                    logger.info("WhatsApp message sent to {}", message.to());
+                    return SmsSendResult.success(name(), null);
+                } else {
+                    logger.warn("WhatsApp provider returned {} for {}", response.getStatusCode(), message.to());
+                    return SmsSendResult.failure(name(), "PROVIDER_REJECTED");
+                }
+
+            } catch (Exception ex) {
+                logger.error("Error sending WhatsApp message to {}", message.to(), ex);
+                return SmsSendResult.failure(name(), mapExceptionToErrorCode(ex));
+            }
+        }, name());
+    }
+
+    private boolean isConfigured() {
+        return StringUtils.hasText(baseUrl);
+    }
+
+    private String mapExceptionToErrorCode(Exception ex) {
+        if (ex instanceof IllegalArgumentException) {
+            return "INVALID_INPUT";
+        }
+        return "PROVIDER_ERROR";
+    }
+}

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/FineractAuthService.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/FineractAuthService.java
@@ -12,14 +12,14 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.util.Collections;
+import java.util.Map;
 
 @Service
 public class FineractAuthService {
 
     private static final Logger logger = LoggerFactory.getLogger(FineractAuthService.class);
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
     private final String fineractApiUrl;
     private final String fineractUser;
     private final String fineractPassword;
@@ -33,11 +33,13 @@ public class FineractAuthService {
     private KeycloakAuthService keycloakAuthService;
 
     public FineractAuthService(RestTemplate restTemplate,
+                               ObjectMapper objectMapper,
                                @Value("${fineract.api.url}") String fineractApiUrl,
                                @Value("${fineract.api.user}") String fineractUser,
                                @Value("${fineract.api.password}") String fineractPassword,
                                @Value("${fineract.api.tenant}") String tenantId) {
         this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
         this.fineractApiUrl = fineractApiUrl;
         this.fineractUser = fineractUser;
         this.fineractPassword = fineractPassword;
@@ -67,10 +69,9 @@ public class FineractAuthService {
 
         String loginUrl = fineractApiUrl + "/authentication";
         
-        ObjectMapper mapper = new ObjectMapper();
         String requestBody;
         try {
-            requestBody = mapper.writeValueAsString(java.util.Map.of(
+            requestBody = objectMapper.writeValueAsString(Map.of(
                     "username", fineractUser,
                     "password", fineractPassword
             ));
@@ -84,7 +85,7 @@ public class FineractAuthService {
             logger.info("Attempting to log in to Fineract at {}", loginUrl);
             String response = restTemplate.postForObject(loginUrl, request, String.class);
             logger.info("Successfully logged in to Fineract");
-            JsonNode root = mapper.readTree(response);
+            JsonNode root = objectMapper.readTree(response);
             this.authToken = root.path("base64EncodedAuthenticationKey").asText();
         } catch (Exception e) {
             logger.error("Failed to log in to Fineract", e);

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/FineractAuthService.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/FineractAuthService.java
@@ -66,7 +66,17 @@ public class FineractAuthService {
         headers.set("Fineract-Platform-TenantId", tenantId);
 
         String loginUrl = fineractApiUrl + "/authentication";
-        String requestBody = String.format("{\"username\": \"%s\", \"password\": \"%s\"}", fineractUser, fineractPassword);
+        
+        ObjectMapper mapper = new ObjectMapper();
+        String requestBody;
+        try {
+            requestBody = mapper.writeValueAsString(java.util.Map.of(
+                    "username", fineractUser,
+                    "password", fineractPassword
+            ));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize Fineract credentials", e);
+        }
 
         HttpEntity<String> request = new HttpEntity<>(requestBody, headers);
 
@@ -74,7 +84,6 @@ public class FineractAuthService {
             logger.info("Attempting to log in to Fineract at {}", loginUrl);
             String response = restTemplate.postForObject(loginUrl, request, String.class);
             logger.info("Successfully logged in to Fineract");
-            ObjectMapper mapper = new ObjectMapper();
             JsonNode root = mapper.readTree(response);
             this.authToken = root.path("base64EncodedAuthenticationKey").asText();
         } catch (Exception e) {

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/KeycloakAuthService.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/KeycloakAuthService.java
@@ -40,6 +40,7 @@ public class KeycloakAuthService {
     private String clientSecret;
 
     private String accessToken;
+    private long tokenExpiryTime;
 
     public KeycloakAuthService(RestTemplate restTemplate, ObjectMapper objectMapper) {
         this.restTemplate = restTemplate;
@@ -47,9 +48,11 @@ public class KeycloakAuthService {
     }
 
     public String getAccessToken() {
-        if (accessToken == null && !authenticate()) {
-            logger.error("Authentication failed. Unable to retrieve access token.");
-            return null;
+        if (accessToken == null || System.currentTimeMillis() >= tokenExpiryTime) {
+            if (!authenticate()) {
+                logger.error("Authentication failed. Unable to retrieve access token.");
+                return null;
+            }
         }
         return accessToken;
     }
@@ -76,7 +79,15 @@ public class KeycloakAuthService {
             if (response.getStatusCode().is2xxSuccessful()) {
                 JsonNode responseBody = objectMapper.readTree(response.getBody());
                 this.accessToken = responseBody.get("access_token").asText();
-                logger.info("Access Token retrieved successfully.");
+                
+                long expiresInSeconds = 300; // Default fallback to 5 minutes
+                if (responseBody.has("expires_in")) {
+                    expiresInSeconds = responseBody.get("expires_in").asLong();
+                }
+                // Set expiry time to (current time + expires_in) minus a 30-second buffer
+                this.tokenExpiryTime = System.currentTimeMillis() + ((expiresInSeconds - 30) * 1000);
+                
+                logger.info("Access Token retrieved successfully. Expires in {} seconds", expiresInSeconds);
                 return true;
             } else {
                 logger.error("Failed to authenticate with Keycloak. Status: {}", response.getStatusCode());

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/KeycloakAuthService.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/KeycloakAuthService.java
@@ -39,15 +39,15 @@ public class KeycloakAuthService {
     @Value("${keycloak.client-secret}")
     private String clientSecret;
 
-    private String accessToken;
-    private long tokenExpiryTime;
+    private volatile String accessToken;
+    private volatile long tokenExpiryTime;
 
     public KeycloakAuthService(RestTemplate restTemplate, ObjectMapper objectMapper) {
         this.restTemplate = restTemplate;
         this.objectMapper = objectMapper;
     }
 
-    public String getAccessToken() {
+    public synchronized String getAccessToken() {
         if (accessToken == null || System.currentTimeMillis() >= tokenExpiryTime) {
             if (!authenticate()) {
                 logger.error("Authentication failed. Unable to retrieve access token.");

--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/SmsService.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/service/SmsService.java
@@ -25,17 +25,22 @@ public class SmsService {
 
     private final Map<String, SmsProvider> providers;
     private final String primaryProvider;
-    private final String fallbackProvider;
+    private final List<String> fallbackProviders;
     private final MeterRegistry meterRegistry;
 
     public SmsService(
             List<SmsProvider> providers,
             @Value("${sms.provider.primary:twilio}") String primaryProvider,
-            @Value("${sms.provider.fallback:}") String fallbackProvider,
+            @Value("${sms.provider.fallback:}") String fallbackProvidersRaw,
             MeterRegistry meterRegistry) {
         this.providers = providers.stream().collect(java.util.stream.Collectors.toMap(SmsProvider::name, provider -> provider));
         this.primaryProvider = primaryProvider;
-        this.fallbackProvider = fallbackProvider;
+        this.fallbackProviders = StringUtils.hasText(fallbackProvidersRaw)
+                ? java.util.Arrays.stream(fallbackProvidersRaw.split(","))
+                        .map(String::trim)
+                        .filter(StringUtils::hasText)
+                        .toList()
+                : java.util.Collections.emptyList();
         this.meterRegistry = meterRegistry;
     }
 
@@ -49,10 +54,23 @@ public class SmsService {
     public SmsSendResult send(SmsMessage message) {
         String requestedProvider = StringUtils.hasText(message.provider()) ? message.provider() : primaryProvider;
         SmsSendResult result = sendWithProvider(requestedProvider, message);
-        if (!result.success() && StringUtils.hasText(fallbackProvider) && !fallbackProvider.equals(requestedProvider)) {
-            logger.warn("SMS provider {} failed for message type {}, attempting fallback", requestedProvider, message.type());
-            result = sendWithProvider(fallbackProvider, message);
+        if (result.success()) {
+            return result;
         }
+
+        // Try fallback providers in order
+        for (String fallback : fallbackProviders) {
+            if (fallback.equals(requestedProvider)) {
+                continue;
+            }
+            logger.warn("SMS provider {} failed for message type {}, attempting fallback {}",
+                    requestedProvider, message.type(), fallback);
+            result = sendWithProvider(fallback, message);
+            if (result.success()) {
+                return result;
+            }
+        }
+
         return result;
     }
 

--- a/fineract-adorsys-sms-gateway/src/main/resources/application.yml
+++ b/fineract-adorsys-sms-gateway/src/main/resources/application.yml
@@ -44,6 +44,8 @@ keycloak:
   client-secret: ${KEYCLOAK_CLIENT_SECRET:**********}
 
 sms:
+  gateway:
+    api-key: ${SMS_GATEWAY_API_KEY:}
   provider:
     primary: ${SMS_PROVIDER_PRIMARY:twilio}
     fallback: ${SMS_PROVIDER_FALLBACK:}

--- a/fineract-adorsys-sms-gateway/src/main/resources/application.yml
+++ b/fineract-adorsys-sms-gateway/src/main/resources/application.yml
@@ -43,6 +43,24 @@ keycloak:
   client-id: ${KEYCLOAK_CLIENT_ID:setup-app-client}
   client-secret: ${KEYCLOAK_CLIENT_SECRET:**********}
 
+sms:
+  provider:
+    primary: ${SMS_PROVIDER_PRIMARY:twilio}
+    fallback: ${SMS_PROVIDER_FALLBACK:}
+  custom-http:
+    url: ${SMS_CUSTOM_HTTP_URL:}
+    api-key: ${SMS_CUSTOM_HTTP_API_KEY:}
+    sender: ${SMS_CUSTOM_HTTP_SENDER:Webank}
+  sns:
+    region: ${SMS_SNS_REGION:}
+    sender-id: ${SMS_SNS_SENDER_ID:Webank}
+    max-price: ${SMS_SNS_MAX_PRICE:}
+  whatsapp:
+    base-url: ${SMS_WHATSAPP_BASE_URL:}
+    device-id: ${SMS_WHATSAPP_DEVICE_ID:}
+  mock:
+    enabled: ${SMS_MOCK_ENABLED:false}
+
 logging:
   level:
     com.example.smsgateway.provider.OrangeSmsProvider: DEBUG


### PR DESCRIPTION
- Add SnsSmsProvider: AWS SNS integration with lazy client init, configurable
  region/sender-id/max-price, and auto-credentials resolution via default chain
- Add WhatsappSmsProvider: WhatsApp delivery via GOWA sidecar
  (POST /send/message with {phone, message})
- Enhance SmsService fallback: replace single fallback string with
  comma-separated multi-provider chain (tries each in order until one succeeds)
- Update application.yml with sms.sns.* and sms.whatsapp.* config entries
- Update PROVIDERS.md with usage docs for SNS, WhatsApp, and new fallback chain