### PR TITLE
fix(sms-gateway): rename API key header from X-KYC-Api-Key to X-SMS-Gateway-Api-Key

### DIFF
--- a/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/ApiKeyFilter.java
+++ b/fineract-adorsys-sms-gateway/src/main/java/com/example/smsgateway/config/ApiKeyFilter.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  */
 public class ApiKeyFilter extends OncePerRequestFilter {
 
-    private static final String API_KEY_HEADER = "X-KYC-Api-Key";
+    private static final String API_KEY_HEADER = "X-SMS-Gateway-Api-Key";
 
     @Value("${sms.gateway.api-key:}")
     private String expectedApiKey;


### PR DESCRIPTION
## Summary

The `ApiKeyFilter` hardcoded the header name `X-KYC-Api-Key`, inherited from the deprecated `webank-kyc-manager`. The SMS gateway is not a KYC manager — it only handles OTP delivery and SMS sending. Rename the header to `X-SMS-Gateway-Api-Key` to match the service's actual purpose.

## Changes
- `ApiKeyFilter.java`: `API_KEY_HEADER` constant renamed from `X-KYC-Api-Key` to `X-SMS-Gateway-Api-Key`

## Coordinated cross-repo changes
This is a coordinated change with the BFF (**webank-mobile**) which sends the same header name via its `smsgateway` client (renamed from `kycmanager`). The BFF PR must be merged together with this one to avoid auth failures.

- **webank-mobile** PR: https://github.com/ADORSYS-GIS/webank-mobile/pull/157
- **webank-verify** README fix: https://github.com/ADORSYS-GIS/webank-verify/pull/10

## Verification
- No tests reference the old header name (confirmed via grep)
- The header value (`SMS_GATEWAY_API_KEY` env var) is unchanged

## AI Usage Declaration
- **AI used for**: Code audit, header rename
- **Verified**: grep confirms no remaining `X-KYC-Api-Key` references in the sms-gateway module