### PR TITLE
fix(sms-gateway): remove circular placeholder reference in application.yml

### DIFF
--- a/fineract-adorsys-sms-gateway/src/main/resources/application.yml
+++ b/fineract-adorsys-sms-gateway/src/main/resources/application.yml
@@ -72,8 +72,14 @@ logging:
 # SMS_GATEWAY_API_KEY). The docker-compose-adorsys.yml stack passes this
 # through from the host environment, defaulting to `dev-sms-gateway-key`
 # so the default stack works out of the box; override it in production.
-SMS_GATEWAY_API_KEY: ${SMS_GATEWAY_API_KEY:}
+#
+# NOTE: SMS_GATEWAY_API_KEY and SMS_GATEWAY_AUTH_DISABLED are NOT declared
+# as YAML keys here. They are read directly by ApiKeyAuthFilter via
+# @Value("${SMS_GATEWAY_API_KEY:}") / @Value("${SMS_GATEWAY_AUTH_DISABLED:false}").
+# Declaring them as `SMS_GATEWAY_API_KEY: ${SMS_GATEWAY_API_KEY:}` below creates
+# a self-referential placeholder that Spring rejects at startup with
+# "Circular placeholder reference" — see ApiKeyAuthFilter for the consumption.
 
-# Dev/test only: set to true to bypass API-key auth entirely. Never enable
-# in production — doing so reopens the open SMS-relay risk this filter closes.
-SMS_GATEWAY_AUTH_DISABLED: ${SMS_GATEWAY_AUTH_DISABLED:false}
+# Dev/test only: set SMS_GATEWAY_AUTH_DISABLED=true to bypass API-key auth
+# entirely. Never enable in production — doing so reopens the open SMS-relay
+# risk this filter closes.


### PR DESCRIPTION
## Problem

The SMS gateway container crashed on startup with:

```
java.lang.IllegalArgumentException: Circular placeholder reference
'SMS_GATEWAY_AUTH_DISABLED:false' in property definitions
```

## Root cause

`application.yml` declared two self-referential YAML keys:

```yaml
SMS_GATEWAY_API_KEY: ${SMS_GATEWAY_API_KEY:}
SMS_GATEWAY_AUTH_DISABLED: ${SMS_GATEWAY_AUTH_DISABLED:false}
```

A YAML property whose value references itself (`${SAME_NAME:default}`) is a circular reference — Spring rejects it at startup.

These values are **already** consumed correctly by `ApiKeyAuthFilter` via `@Value("${SMS_GATEWAY_API_KEY:}")` and `@Value("${SMS_GATEWAY_AUTH_DISABLED:false}")`, so the YAML entries were both redundant and the source of the crash.

## Fix

Removed the two self-referential YAML keys. Kept and expanded the explanatory comments to document why they must not be re-declared as YAML keys (so the regression is not reintroduced).

## Verification

- Built the image locally and ran it in the webank-mobile fullstack stack.
- Container is `Up (healthy)` and logs show `Started SmsGatewayApplication` with no exceptions.

```
2026-07-08T12:31:48.228Z  INFO ... Tomcat started on port(s): 8080 (http) with context path ''
2026-07-08T12:31:48.307Z  INFO ... Started SmsGatewayApplication in 13.561 seconds
```

## AI Usage Declaration

- **AI used for**: root-cause analysis of the startup stack trace, applying the fix, drafting this PR.
- **Verified by**: local Docker build + run, container health check, log inspection.

Source of truth: `ApiKeyAuthFilter.java` (`@Value` consumption of these properties).