### PR TITLE
fix: add workflows permission to upstream sync workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Compute branch name
         id: branch
         run: |
-          BRANCH_NAME="sync/upstream-$(date +%Y-%m)"
+          BRANCH_NAME="$(date +%Y-%m-%d)"
           echo "name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Check if sync is needed

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -27,6 +27,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  workflows: write
 
 jobs:
   sync:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Compute branch name
         id: branch
         run: |
-          BRANCH_NAME="$(date +%Y-%m-%d)"
+          BRANCH_NAME="sync/upstream-$(date +%Y-%m-%d)"
           echo "name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
       - name: Check if sync is needed


### PR DESCRIPTION
The workflow was failing when trying to push branches that contain workflow files: "refusing to allow a GitHub App to create or update workflow `.github/workflows/build-cucumber.yml` without `workflows` permission"

Added `workflows: write` permission to allow the workflow to create and update workflow files during upstream sync.

## Description

Describe the changes made and why they were made. (Ignore if these details are present on the associated Apache Fineract JIRA ticket.)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per [our guidelines](https://github.com/apache/fineract/blob/develop/CONTRIBUTING.md#pull-requests)
- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.
- [ ] Create/update [unit or integration tests](https://fineract.apache.org/docs/current/#_testing) for verifying the changes made.
- [ ] Follow our [coding conventions](https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions).
- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes
- [ ] [This PR must not be a "code dump"](https://cwiki.apache.org/confluence/display/FINERACT/Pull+Request+Size+Limit). Large changes can be made in a branch, with assistance. Ask for help on the [developer mailing list](https://fineract.apache.org/#contribute).

Your assigned reviewer(s) will follow our [guidelines for code reviews](https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide).
