### PR TITLE
fix: use PAT for upstream sync to allow pushing workflow file changes

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -27,7 +27,6 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  workflows: write
 
 jobs:
   sync:
@@ -38,7 +37,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN can never create/update files under .github/workflows/
+          # (GitHub hard-blocks this regardless of the `permissions:` block above).
+          # Since upstream syncs routinely touch workflow files, we need a PAT
+          # with the `workflow` scope (classic) or "Workflows: Read and write"
+          # (fine-grained), stored as the SYNC_PAT repository secret.
+          token: ${{ secrets.SYNC_PAT }}
           persist-credentials: false
 
       - name: Add upstream remote
@@ -48,8 +52,9 @@ jobs:
 
       - name: Configure origin remote with auth
         run: |
-          # Configure origin with the GitHub token for authentication
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          # Configure origin with the PAT for authentication so we can push
+          # branches containing changes to .github/workflows/*
+          git remote set-url origin https://x-access-token:${{ secrets.SYNC_PAT }}@github.com/${{ github.repository }}.git
 
       - name: Compute branch name
         id: branch


### PR DESCRIPTION
## Problem

The `sync-upstream.yml` workflow was failing to push branches that contained changes to `.github/workflows/*` files (e.g. `build-cucumber.yml`):

```
refusing to allow a GitHub App to create or update workflow .github/workflows/build-cucumber.yml without workflows permission
```

A previous fix (#146) added a `workflows: write` entry to the workflow's `permissions:` block, but this caused a new failure:

```
Invalid workflow file: .github/workflows/sync-upstream.yml#L1
(Line: 30, Col: 3): Unexpected value 'workflows'.
```

`workflows` is not a valid key in the `permissions:` schema (valid keys are `contents`, `issues`, `pull-requests`, etc.). More importantly, even a valid `permissions:` entry would not fix the root cause: **`GITHUB_TOKEN` is hard-blocked by GitHub from ever creating or updating files under `.github/workflows/`**, regardless of the permissions granted to it. This is an intentional platform-level restriction, not something `permissions:` can lift.

## Fix

- Removed the invalid `workflows: write` permission.
- Switched the `actions/checkout` `token:` input and the `origin` remote auth to use a new `SYNC_PAT` repository secret instead of `secrets.GITHUB_TOKEN`.
- `SYNC_PAT` should be a personal access token with:
  - **Classic PAT:** `repo` + `workflow` scopes, or
  - **Fine-grained PAT:** `Contents: Read and write` + `Workflows: Read and write` (+ `Pull requests`/`Issues` write if desired)
- Left the `gh pr create` / `gh issue create` steps on `secrets.GITHUB_TOKEN`, since those don't touch workflow files and the existing `pull-requests: write` / `issues: write` permissions are sufficient.

## Required follow-up (repo admin)

This PR alone is not sufficient — a `SYNC_PAT` secret must be added under **Settings → Secrets and variables → Actions** before the sync workflow will succeed on branches that touch `.github/workflows/*`.

## Testing

- Validated the workflow YAML parses correctly with `yaml.safe_load`.