### PR TITLE
fix: delete stale sync branch before recreating it

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -119,6 +119,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # A stale branch with today's date may still exist on origin from a
+          # previous run whose PR was closed without merging (closing a PR
+          # does not delete its branch). We already confirmed above that no
+          # OPEN PR/issue references this branch name, so it's safe to drop
+          # any leftover remote branch before recreating it.
+          git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
+
           git checkout -b "$BRANCH_NAME" develop
 
           if git merge upstream/develop --no-edit; then


### PR DESCRIPTION
## Problem

Manually triggering the sync workflow today (after merging #149 but the
manual run happened before that merge) resulted in:

```
! [rejected]  sync/upstream-2026-07-27 -> sync/upstream-2026-07-27 (non-fast-forward)
error: failed to push some refs to 'https://github.com/ADORSYS-GIS/fineract.git'
```

Root cause: an earlier run had already pushed `sync/upstream-2026-07-27`
and opened PR #148 against it. That PR was closed manually (it was a
placeholder/junk PR created before the `--label` fix landed), but
**closing a PR does not delete its branch**. Branch names are date-based
(`sync/upstream-YYYY-MM-DD`), so a same-day re-run tries to push a new
merge commit to that same branch name and gets rejected as a
non-fast-forward push.

The existing-PR/issue duplicate check added in #149 only guards against
duplicate **open** PRs/issues — it doesn't account for a closed PR whose
branch is still sitting on `origin`.

## Fix

Since `sync/upstream-*` branches are fully bot-owned and disposable,
delete any stale remote branch with the same name right before
recreating it in the "Create sync branch and merge" step. This is safe
specifically because the prior step already confirmed no open PR/issue
references this branch name.

```bash
git push origin --delete "$BRANCH_NAME" 2>/dev/null || true
git checkout -b "$BRANCH_NAME" develop
```

## Also done manually
Deleted the stale `sync/upstream-2026-07-27` branch on `origin` directly
so the very next run (before this PR merges) doesn't hit the same
collision.