### PR TITLE
fix: bump publish-ghcr workflow to JDK 25

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'zulu'
 
       - name: Setup Gradle


### PR DESCRIPTION
## Problem

The upstream sync pulled in apache/fineract's **FINERACT-2734 "Upgrade to JDK 25 LTS"**, which moved the build toolchain to **Java 25** (`build.gradle:408`) and the Docker base image to `azul/zulu-openjdk-alpine:25` (`custom/docker/build.gradle:27`).

However, the fork-only deploy workflow **`publish-ghcr.yml`** was still provisioning **JDK 21**. Because `:custom:docker` depends on `:fineract-provider` / `:fineract-core` (now toolchain-25), the `:custom:docker:jib` build fails:

```
Could not resolve all dependencies for configuration ':custom:docker:runtimeClasspath'.
  > Could not resolve project :fineract-core.
      > ... only compatible with JVM runtime version 25 or newer.
```

This broke the deploy that builds and pushes the Apache Fineract image to GHCR.

## Fix

Bump `publish-ghcr.yml` from JDK 21 to **JDK 25** (Zulu), matching the synced upstream toolchain and the other workflows.

## Verification

- Root build requires Java 25 toolchain (`build.gradle:408`).
- Upstream's own workflows (e.g. `publish-dockerhub.yml`) were already bumped to JDK 25.
- No Jib/plugin version change needed — Jib 3.5.3 and layer-filter 0.3.0 are unaffected.